### PR TITLE
fix: surface vault-init postgres connection errors and reduce CI timeout risk

### DIFF
--- a/scripts/vault-init-dependencies.sh
+++ b/scripts/vault-init-dependencies.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
-if ! command -v bash >/dev/null 2>&1; then
+if ! command -v bash >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 || ! command -v psql >/dev/null 2>&1; then
   apk update
+fi
+if ! command -v bash >/dev/null 2>&1; then
   apk add bash
 fi
 if ! command -v jq >/dev/null 2>&1; then
-  apk update
   apk add jq
 fi
 if ! command -v psql >/dev/null 2>&1; then
-  apk update
   apk add postgresql-client
 fi
 

--- a/scripts/vault-init.sh
+++ b/scripts/vault-init.sh
@@ -7,7 +7,7 @@ export VAULT_ADDR=http://vault:8200
 
 ###############################################################
 
-: "${TIMEOUT_SECONDS:=60}" # env var with default fallback
+: "${TIMEOUT_SECONDS:=120}" # env var with default fallback
 
 ###############################################################
 
@@ -17,9 +17,10 @@ set_status() {
 }
 
 wait_for_postgres() {
+    local last_error=""
     SECONDS_DELTA=$SECONDS
     while [[ $(($SECONDS - $SECONDS_DELTA)) -lt "$TIMEOUT_SECONDS" ]]; do
-        if psql -c "SELECT 1" > /dev/null 2>&1; then
+        if last_error=$(psql -c "SELECT 1" 2>&1 > /dev/null); then
             echo "Postgres is ready"
             return 0
         fi
@@ -27,6 +28,7 @@ wait_for_postgres() {
     done
 
     >&2 echo "Timed out waiting for Postgres to become ready"
+    >&2 echo "Last psql error: $last_error"
     return 1
 }
 


### PR DESCRIPTION
### Description

The "Run Tests" CI job has been failing consistently (both before and after 3f896ce) with vault-init exiting 1 after ~60-70s, but the real psql error was swallowed (`> /dev/null 2>&1`), leaving only a bare exit code in the logs. wait_for_postgres now surfaces the last psql error on timeout, the timeout budget is bumped to 120s, and vault-init-dependencies.sh runs a single `apk update` instead of three, shaving time off before the postgres wait even starts.

