### PR TITLE
Fix/ci test run

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,21 +6,39 @@ jobs:
   test:
     name: Testing
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Deliberately looser than the step timeouts below. A job-level timeout
+    # cancels the job outright, so `if: failure()` steps never get to run.
+    timeout-minutes: 60
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Enable corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
-          cache: "yarn"
-          cache-dependency-path: "tests/yarn.lock"
+          node-version: '22.x'
+          cache: 'yarn'
+          cache-dependency-path: 'tests/yarn.lock'
       - name: install dependencies
         run: yarn --immutable
         working-directory: tests
-      - name: test
-        run: yarn test
+      # Split from `yarn test` so startup and the suite are timed and bounded
+      # separately, and so teardown still runs when either fails
+      - name: start environment
+        run: yarn test:start
+        working-directory: tests
+        timeout-minutes: 12
+      - name: run tests
+        run: yarn test:run
+        working-directory: tests
+        timeout-minutes: 40
+      - name: dump environment logs
+        if: failure()
+        run: |
+          docker compose --env-file envs/latest ps --all || true
+          docker compose --env-file envs/latest logs --no-color --timestamps || true
+      - name: stop environment
+        if: always()
+        run: yarn test:stop
         working-directory: tests

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Notes:
 - `--allow-unprotected-txs` is enabled for local experimentation with legacy transaction flows.
 - Blockscout uses dedicated Postgres and Redis services, separate from Subquery services.
 - If you customize ports, keep frontend `NEXT_PUBLIC_API_PORT` aligned with `POLYMESH_BLOCKSCOUT_BACKEND_PORT`.
+- The upstream Blockscout frontend image enables third-party ad slots by default (a banner on the home page and a text ad on token pages). This environment disables them; set `POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER` / `POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER` to a provider name to re-enable.
 - `envs/7.2` does not include EVM settings because chain v7.2 is not EVM-compatible.
 - Treat EVM support as a v8+ feature set. Use v7.2 only for legacy non-EVM scenarios.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -365,6 +365,11 @@ services:
       # Required to enable in-browser wallet interaction (contract Write tab,
       # MetaMask, etc). Get a free project ID from https://cloud.reown.com
       NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${POLYMESH_BLOCKSCOUT_WALLET_CONNECT_PROJECT_ID:-}
+      # The upstream frontend image enables third-party ad slots by default
+      # (a banner on the home page and a text ad on token pages). They are
+      # disabled here; set a provider name to re-enable.
+      NEXT_PUBLIC_AD_BANNER_PROVIDER: ${POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER:-none}
+      NEXT_PUBLIC_AD_TEXT_PROVIDER: ${POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER:-none}
 
   vault:
     # DEVELOPMENT ONLY. This Vault is not a template for a real deployment: it

--- a/compose.yaml
+++ b/compose.yaml
@@ -367,6 +367,12 @@ services:
       NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${POLYMESH_BLOCKSCOUT_WALLET_CONNECT_PROJECT_ID:-}
 
   vault:
+    # DEVELOPMENT ONLY. This Vault is not a template for a real deployment: it
+    # runs without TLS, initializes with a single unseal key, and writes both
+    # that key and the root token in plaintext to a volume other services read.
+    # `disable_mlock` is set in vault-config.json because the image runs as
+    # non-root and its binary carries no cap_ipc_lock file capability, so mlock
+    # fails wherever the host's memlock rlimit is finite.
     image: hashicorp/vault:${VAULT_VERSION:-latest}
     networks:
       - polymesh
@@ -376,8 +382,6 @@ services:
     volumes:
       - vault-volume:/vault/file:rw
       - vault-log-volume:/vault/logs:rw
-    cap_add:
-      - IPC_LOCK # Prevents secrets from swapping to disk
     configs:
       - source: vault-config
         target: /vault/config/vault.json

--- a/envs/8.0
+++ b/envs/8.0
@@ -41,3 +41,7 @@ POLYMESH_SUBQUERY_GRAPHQL_PORT=3000
 # Enables in-browser wallet interaction (contract Write tab, MetaMask, etc).
 # Get a free project ID from https://cloud.reown.com
 # POLYMESH_BLOCKSCOUT_WALLET_CONNECT_PROJECT_ID=
+# Third-party ad slots are disabled by default. Set a provider name
+# (e.g. slise, coinzilla) to re-enable them.
+# POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER=none
+# POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER=none

--- a/envs/latest
+++ b/envs/latest
@@ -40,3 +40,7 @@ POLYMESH_SUBQUERY_GRAPHQL_PORT=3000
 # Enables in-browser wallet interaction (contract Write tab, MetaMask, etc).
 # Get a free project ID from https://cloud.reown.com
 # POLYMESH_BLOCKSCOUT_WALLET_CONNECT_PROJECT_ID=
+# Third-party ad slots are disabled by default. Set a provider name
+# (e.g. slise, coinzilla) to re-enable them.
+# POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER=none
+# POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER=none

--- a/envs/local
+++ b/envs/local
@@ -40,3 +40,7 @@ POLYMESH_SUBQUERY_GRAPHQL_PORT=3000
 # Enables in-browser wallet interaction (contract Write tab, MetaMask, etc).
 # Get a free project ID from https://cloud.reown.com
 # POLYMESH_BLOCKSCOUT_WALLET_CONNECT_PROJECT_ID=
+# Third-party ad slots are disabled by default. Set a provider name
+# (e.g. slise, coinzilla) to re-enable them.
+# POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER=none
+# POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER=none

--- a/envs/template
+++ b/envs/template
@@ -49,6 +49,10 @@ POLYMESH_SUBQUERY_GRAPHQL_PORT=3000
 # POLYMESH_BLOCKSCOUT_NETWORK_SHORT_NAME=Polymesh
 # POLYMESH_BLOCKSCOUT_COIN_DECIMALS=18
 # POLYMESH_BLOCKSCOUT_IS_TESTNET=true
+# Third-party ad slots are disabled by default. Set a provider name
+# (e.g. slise, coinzilla) to re-enable them.
+# POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER=none
+# POLYMESH_BLOCKSCOUT_AD_TEXT_PROVIDER=none
 
 # Optional vault image override
 # VAULT_VERSION=latest

--- a/scripts/start-env.sh
+++ b/scripts/start-env.sh
@@ -66,7 +66,14 @@ if [[ -n "$COMPOSE_PULL_POLICY" ]]; then
 fi
 
 echo "[START ENV] Starting env using $COMPOSE_ENV"
-docker compose "${COMPOSE_ARGS[@]}" up "${UP_ARGS[@]}"
+# `up --detach` never attaches to container stdout, so a failing one-shot service
+# reports only "didn't complete successfully: exit N" with no indication of why
+if ! docker compose "${COMPOSE_ARGS[@]}" up "${UP_ARGS[@]}"; then
+	echo "[START ENV] Environment failed to start, dumping container state and logs..."
+	docker compose "${COMPOSE_ARGS[@]}" ps --all || true
+	docker compose "${COMPOSE_ARGS[@]}" logs --no-color --timestamps --tail "${COMPOSE_FAILURE_LOG_TAIL:-200}" || true
+	exit 1
+fi
 
 echo "[START ENV] Waiting for a fully initialized environment..."
 # `|| true` swallows all errors, but `docker wait` exits with non-zero in the expected case

--- a/scripts/vault-config.json
+++ b/scripts/vault-config.json
@@ -12,6 +12,7 @@
     },
     "default_lease_ttl":"168h",
     "max_lease_ttl":"0h",
+    "disable_mlock": true,
     "ui":true,
     "log_level":"Debug"
 }

--- a/scripts/vault-init.sh
+++ b/scripts/vault-init.sh
@@ -48,6 +48,11 @@ initialize_vault() {
 
 unseal_vault() {
     local key
+    if [ ! -f /vault-token/.unseal_key ]; then
+        >&2 echo "Vault reports initialized but /vault-token/.unseal_key is missing."
+        >&2 echo "The vault-volume and vault-root-token volumes are out of sync, remove both and restart."
+        return 1
+    fi
     key=$(cat /vault-token/.unseal_key)
     vault operator unseal $key
 
@@ -106,15 +111,15 @@ while [[ $(($SECONDS - $SECONDS_DELTA)) -lt "$TIMEOUT_SECONDS" ]]; do
     sleep 1
 done
 
+if [ "$READY" = false ]; then
+    >&2 echo "Timed out waiting for Vault to become ready after ${TIMEOUT_SECONDS}s"
+    >&2 echo "Last Vault status: ${STATUS:-<no response from $VAULT_ADDR>}"
+    exit 1
+fi
+
 # Output Vault Root Token
 echo "Vault Root Token: $(cat /vault-token/.token)"
 
 set_status "true"
-
-if [ "$READY" = false ]; then
-    >&2 echo "Timed out waiting for Vault to become ready"
-    set_status "false"
-    exit 1
-fi
 
 ###############################################################

--- a/tests/package.json
+++ b/tests/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@polymeshassociation/local-signing-manager": "^4.1.1",
-    "@polymeshassociation/polymesh-sdk": "30.0.0",
+    "@polymeshassociation/polymesh-sdk": "30.1.0",
     "cross-fetch": "^4.1.0",
     "dotenv": "^16.5.0"
   },
@@ -63,7 +63,24 @@
     "@polkadot/rpc-provider": "16.5.2",
     "@polkadot/types": "16.5.2",
     "@polkadot/types-augment": "16.5.2",
-    "@polkadot/types-known": "16.5.2"
+    "@polkadot/types-known": "16.5.2",
+    "@polkadot/keyring": "13.5.9",
+    "@polkadot/networks": "13.5.9",
+    "@polkadot/util": "13.5.9",
+    "@polkadot/util-crypto": "13.5.9",
+    "@polkadot/x-bigint": "13.5.9",
+    "@polkadot/x-fetch": "13.5.9",
+    "@polkadot/x-global": "13.5.9",
+    "@polkadot/x-randomvalues": "13.5.9",
+    "@polkadot/x-textdecoder": "13.5.9",
+    "@polkadot/x-textencoder": "13.5.9",
+    "@polkadot/x-ws": "13.5.9",
+    "@polkadot/wasm-bridge": "7.5.4",
+    "@polkadot/wasm-crypto": "7.5.4",
+    "@polkadot/wasm-crypto-asmjs": "7.5.4",
+    "@polkadot/wasm-crypto-init": "7.5.4",
+    "@polkadot/wasm-crypto-wasm": "7.5.4",
+    "@polkadot/wasm-util": "7.5.4"
   },
   "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
 }

--- a/tests/src/helpers/admin-setup.ts
+++ b/tests/src/helpers/admin-setup.ts
@@ -1,12 +1,19 @@
 import 'tsconfig-paths/register'; // (Solution from)[https://github.com/facebook/jest/issues/11644#issuecomment-1171646729]
 
 import { RestClient } from '~/rest';
+import { Identity } from '~/rest/identities';
+import { RestErrorResult, ResultSet } from '~/rest/interfaces';
 import { VaultClient } from '~/vault';
 
 import { env } from '../environment';
 
 const maxWorkersSupported = 8;
 
+// Each Jest worker gets one admin, funded once here. Do not raise this:
+// createTestAdmins transfers from a finite source account and fails the whole
+// call with FundsUnavailable when asked for more than it holds. Headroom for
+// the suites comes from the other side of the ledger, `startingPolyx` in
+// helpers/factory.ts, which is sized well below this budget.
 const startingPolyx = 1000000;
 
 export default async (): Promise<void> => {
@@ -23,5 +30,20 @@ export default async (): Promise<void> => {
   }));
 
   // Idempotent on v8: registers missing identities and (re)funds POLYX each run
-  await restClient.identities.createTestAdmins(accounts);
+  const result = (await restClient.identities.createTestAdmins(accounts)) as
+    | ResultSet<Identity>
+    | RestErrorResult;
+
+  // Fail here rather than let every suite fail later on transaction fees
+  if ('statusCode' in result && result.statusCode >= 400) {
+    throw new Error(`createTestAdmins failed (${result.statusCode}): ${result.message}`);
+  }
+
+  if (!('results' in result) || result.results?.length !== accounts.length) {
+    throw new Error(
+      `createTestAdmins funded ${('results' in result && result.results?.length) || 0} of ${
+        accounts.length
+      } admin accounts`
+    );
+  }
 };

--- a/tests/src/helpers/factory.ts
+++ b/tests/src/helpers/factory.ts
@@ -11,7 +11,11 @@ import { alphabet, isChainV7, randomNonce } from '~/util';
 import { VaultClient } from '~/vault';
 
 const nonceLength = 9;
-const startingPolyx = 100000;
+// Paid by the worker's admin for every identity a suite creates, out of the
+// budget it is given in helpers/admin-setup.ts. Keep it well clear of what a
+// suite actually spends, protocol fees are 2_500 to create an asset and 500 for
+// a ticker, and no test moves more than 1_000 POLYX.
+const startingPolyx = 25000;
 const { nodeUrl, vaultUrl, vaultToken, vaultTransitPath } = env;
 
 export class TestFactory {

--- a/tests/src/sdk/assets/controllerTransfer.ts
+++ b/tests/src/sdk/assets/controllerTransfer.ts
@@ -1,10 +1,51 @@
 import { BigNumber, Polymesh } from '@polymeshassociation/polymesh-sdk';
-import { KnownNftType, MetadataType, VenueType } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  Account,
+  Instruction,
+  KnownNftType,
+  MetadataType,
+  VenueType,
+} from '@polymeshassociation/polymesh-sdk/types';
 import assert from 'node:assert';
 
 import { createAsset } from '~/sdk/assets/createAsset';
 import { createNftCollection } from '~/sdk/assets/createNftCollection';
-import { awaitMiddlewareSynced, getPendingInstructionEndBlock, sleep } from '~/util';
+import { awaitMiddlewareSynced, sleep } from '~/util';
+
+/**
+ * Wait for an instruction the counter party only receives on to settle,
+ * affirming as the receiver when the chain requires it.
+ *
+ * The submitter affirms on submission, and from chain v8 a party that only
+ * receives is affirmed automatically unless it has opted in through
+ * settlement.setMandatoryReceiverAffirmation. Such an instruction therefore
+ * settles with no further action and never reaches the receiver's pending list.
+ * Earlier chains need the receiver's affirmation before it can execute.
+ */
+const settleAsReceiver = async (
+  instruction: Instruction,
+  receiverAccount: Account,
+  retries = 15,
+  delay = 2000
+): Promise<void> => {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    if (await instruction.isExecuted()) {
+      return;
+    }
+
+    // An instruction with affirmations outstanding cannot execute, and the count
+    // reads zero once it has, so this cannot race with settlement
+    if ((await instruction.getPendingAffirmationCount()).gt(0)) {
+      const affirmTx = await instruction.affirm({}, { signingAccount: receiverAccount });
+      await affirmTx.run();
+      assert(affirmTx.isSuccess, 'the receiver should be able to affirm the instruction');
+    }
+
+    await sleep(delay);
+  }
+
+  assert(await instruction.isExecuted(), 'the transfer instruction should have settled');
+};
 
 /*
   This script showcases VenueFiltering related functionality. It:
@@ -30,8 +71,6 @@ export const fungibleAssetControllerTransfer = async (
   assert(signerIdentity);
   const { account: counterPartyAccount } = await counterParty.getPrimaryAccount();
 
-  const endBlock = await getPendingInstructionEndBlock(sdk);
-
   const venueTx = await sdk.settlements.createVenue({
     description: 'Controller transfer venue',
     type: VenueType.Exchange,
@@ -39,30 +78,15 @@ export const fungibleAssetControllerTransfer = async (
   const venue = await venueTx.run();
   assert(venueTx.isSuccess);
 
+  // No end block, so the instruction settles as soon as it is fully affirmed.
+  // The controller transfer below needs the counter party to hold the asset
   const transferTx = await venue.addInstruction({
     legs: [{ asset, from: signerIdentity, to: targetDid, amount: new BigNumber(1000) }],
-    endBlock,
   });
   const instruction = await transferTx.run();
   assert(transferTx.isSuccess);
 
-  await awaitMiddlewareSynced(transferTx, sdk, 30, 3000);
-
-  // affirm instruction
-  let counterInstruction;
-  for (let attempt = 0; attempt < 10; attempt++) {
-    const { pending } = await counterParty.getInstructions();
-    counterInstruction = pending.find(({ id }) => id.eq(instruction.id));
-    if (counterInstruction) {
-      break;
-    }
-    await sleep(2000);
-  }
-  assert(counterInstruction, 'the counter party should have the instruction as pending');
-
-  const affirmTx = await counterInstruction.affirm({}, { signingAccount: counterPartyAccount });
-  await affirmTx.run();
-  assert(affirmTx.isSuccess);
+  await settleAsReceiver(instruction, counterPartyAccount);
 
   const controllerTransferTx = await asset.controllerTransfer({
     originPortfolio: targetDid,
@@ -72,15 +96,17 @@ export const fungibleAssetControllerTransfer = async (
 
   assert(controllerTransferTx.isSuccess);
 
+  await awaitMiddlewareSynced(controllerTransferTx, sdk, 30, 3000);
+
   const assetHolders = await asset.assetHolders.get();
 
   const heldByIssuer = assetHolders.data.find(({ identity }) => identity.isEqual(signerIdentity));
   assert(heldByIssuer);
-  expect(heldByIssuer.balance.eq(new BigNumber(1100)));
+  expect(heldByIssuer.balance.toNumber()).toEqual(1100);
 
   const heldByCounterParty = assetHolders.data.find(({ identity }) => identity.did === targetDid);
   assert(heldByCounterParty);
-  expect(heldByCounterParty.balance.eq(new BigNumber(900)));
+  expect(heldByCounterParty.balance.toNumber()).toEqual(900);
 };
 
 /*
@@ -147,8 +173,6 @@ export const nonFungibleAssetControllerTransfer = async (
 
   const nft2 = await issueTx2.run();
 
-  const endBlock = await getPendingInstructionEndBlock(sdk);
-
   const venueTx = await sdk.settlements.createVenue({
     description: 'Controller transfer venue',
     type: VenueType.Exchange,
@@ -156,23 +180,15 @@ export const nonFungibleAssetControllerTransfer = async (
   const venue = await venueTx.run();
   assert(venueTx.isSuccess);
 
+  // No end block, so the instruction settles as soon as it is fully affirmed.
+  // The controller transfer below needs the counter party to hold the NFTs
   const transferTx = await venue.addInstruction({
     legs: [{ asset: collection, nfts: [nft, nft2], from: signerIdentity, to: targetDid }],
-    endBlock,
   });
   const instruction = await transferTx.run();
   assert(transferTx.isSuccess);
 
-  await awaitMiddlewareSynced(transferTx, sdk);
-
-  // affirm instruction
-  const { pending } = await counterParty.getInstructions();
-  const counterInstruction = pending.find(({ id }) => id.eq(instruction.id));
-  assert(counterInstruction, 'the counter party should have the instruction as pending');
-
-  const affirmTx = await counterInstruction.affirm({}, { signingAccount: counterPartyAccount });
-  await affirmTx.run();
-  assert(affirmTx.isSuccess);
+  await settleAsReceiver(instruction, counterPartyAccount);
 
   const controllerTransferTx = await collection.controllerTransfer({
     originPortfolio: targetDid,
@@ -181,6 +197,8 @@ export const nonFungibleAssetControllerTransfer = async (
   await controllerTransferTx.run();
 
   assert(controllerTransferTx.isSuccess);
+
+  await awaitMiddlewareSynced(controllerTransferTx, sdk);
 
   const assetHolders = await collection.assetHolders.get({});
 
@@ -207,6 +225,8 @@ export const nonFungibleAssetControllerTransfer = async (
   await controllerTransferTx2.run();
 
   assert(controllerTransferTx2.isSuccess);
+
+  await awaitMiddlewareSynced(controllerTransferTx2, sdk);
 
   const assetHolders2 = await collection.assetHolders.get({});
 

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1029,28 +1029,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/keyring@npm:13.5.8"
+"@polkadot/keyring@npm:13.5.9":
+  version: 13.5.9
+  resolution: "@polkadot/keyring@npm:13.5.9"
   dependencies:
-    "@polkadot/util": "npm:13.5.8"
-    "@polkadot/util-crypto": "npm:13.5.8"
+    "@polkadot/util": "npm:13.5.9"
+    "@polkadot/util-crypto": "npm:13.5.9"
     tslib: "npm:^2.8.0"
   peerDependencies:
-    "@polkadot/util": 13.5.8
-    "@polkadot/util-crypto": 13.5.8
-  checksum: 10c0/fe12be671112849f481cd406c9c87c9f7bc3bf1f25f1bb1db67fae70807f832d3e5849e6c282994c747de4228b9bf2bf4a262376b4042f18a255b5b81e43c392
-  languageName: node
-  linkType: hard
-
-"@polkadot/networks@npm:13.5.8, @polkadot/networks@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/networks@npm:13.5.8"
-  dependencies:
-    "@polkadot/util": "npm:13.5.8"
-    "@substrate/ss58-registry": "npm:^1.51.0"
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/2574d7a865d4851d75c13e0132d20ab4b129595f9fa2eb44e7075be9ea5e9e01b0b05ef794d35b33f455a7a5abeb6b972c7acc8ecf0ac9b47983d650ed4669f2
+    "@polkadot/util": 13.5.9
+    "@polkadot/util-crypto": 13.5.9
+  checksum: 10c0/bc131a70cb02280f4dcf1b0e3a7b5114e70d94f62c53917f196f985d2efa6b484489b28f4d24a788e3cf66cab2e763285a3b0a427b2b9eade1c1e5fa89325ccb
   languageName: node
   linkType: hard
 
@@ -1190,26 +1179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:13.5.8, @polkadot/util-crypto@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/util-crypto@npm:13.5.8"
-  dependencies:
-    "@noble/curves": "npm:^1.3.0"
-    "@noble/hashes": "npm:^1.3.3"
-    "@polkadot/networks": "npm:13.5.8"
-    "@polkadot/util": "npm:13.5.8"
-    "@polkadot/wasm-crypto": "npm:^7.5.2"
-    "@polkadot/wasm-util": "npm:^7.5.2"
-    "@polkadot/x-bigint": "npm:13.5.8"
-    "@polkadot/x-randomvalues": "npm:13.5.8"
-    "@scure/base": "npm:^1.1.7"
-    tslib: "npm:^2.8.0"
-  peerDependencies:
-    "@polkadot/util": 13.5.8
-  checksum: 10c0/2852e00fafe307ca6547e93565a7cb3a744b74b216c3c7a4ef0101cdc5f708234d0562b148857746b34a3d87187190f3ca290178316ac04eeaf52b760e622d13
-  languageName: node
-  linkType: hard
-
 "@polkadot/util-crypto@npm:13.5.9":
   version: 13.5.9
   resolution: "@polkadot/util-crypto@npm:13.5.9"
@@ -1230,21 +1199,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:13.5.8, @polkadot/util@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/util@npm:13.5.8"
-  dependencies:
-    "@polkadot/x-bigint": "npm:13.5.8"
-    "@polkadot/x-global": "npm:13.5.8"
-    "@polkadot/x-textdecoder": "npm:13.5.8"
-    "@polkadot/x-textencoder": "npm:13.5.8"
-    "@types/bn.js": "npm:^5.1.6"
-    bn.js: "npm:^5.2.1"
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/494e5f4bfcd8efa88c42a863e0b0b00ee9a53de2b1b27f359e08ed73c4ce07ba07447f2380bfbc0bd1029d9e936247ce4aac681222c33f7717ab9eb18e28f0bc
-  languageName: node
-  linkType: hard
-
 "@polkadot/util@npm:13.5.9":
   version: 13.5.9
   resolution: "@polkadot/util@npm:13.5.9"
@@ -1257,19 +1211,6 @@ __metadata:
     bn.js: "npm:^5.2.1"
     tslib: "npm:^2.8.0"
   checksum: 10c0/6ef6d57c3e05c86bf25c3d6d282b49ae16960c1983de3765c3f174636e2b074bddb035472ef0ad8380c8a474179a34e5916663a4846b716807362354524a0408
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-bridge@npm:7.5.3":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-bridge@npm:7.5.3"
-  dependencies:
-    "@polkadot/wasm-util": "npm:7.5.3"
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 10c0/b34d65f2b0213df8affdd1dd6aaf56dbaadbbe7901a66e764da9412a4e1de7b6ccc8bf524432516cd0eeecc25b2e47b51a021dab94f72ac01974e6319bfe0bbe
   languageName: node
   linkType: hard
 
@@ -1286,17 +1227,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:7.5.3":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:7.5.3"
-  dependencies:
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: 10c0/af6dce7f3f548a5e4385c346dac21084a8782f9202aed047617b6f385557674bccc20b06517288db3afd0c72ed4adb6a0c8e87316495c6be49a5ef32fb61e6b7
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-asmjs@npm:7.5.4":
   version: 7.5.4
   resolution: "@polkadot/wasm-crypto-asmjs@npm:7.5.4"
@@ -1305,22 +1235,6 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: 10c0/4dcbef752ce17f9bf5731743b55186a4b319aef590103bd3bb66a5627c0b66ec5f97beb3d1be96ac61c68c765b4f0c3d088d54b6cc5d1b651d14dc9243359b70
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto-init@npm:7.5.3":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-crypto-init@npm:7.5.3"
-  dependencies:
-    "@polkadot/wasm-bridge": "npm:7.5.3"
-    "@polkadot/wasm-crypto-asmjs": "npm:7.5.3"
-    "@polkadot/wasm-crypto-wasm": "npm:7.5.3"
-    "@polkadot/wasm-util": "npm:7.5.3"
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 10c0/41b0c9d8bc9e0f7c11e22030fd53206767f41e064f94cd392a178ad6012b1eb6b1f6ef19a6442863ce0a8e2210ed863ec6b4687b429d60c5de560efae789ea47
   languageName: node
   linkType: hard
 
@@ -1340,18 +1254,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:7.5.3":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-crypto-wasm@npm:7.5.3"
-  dependencies:
-    "@polkadot/wasm-util": "npm:7.5.3"
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: 10c0/12f3d3a8a75f97ef6153b1a7b52e698a428a80a8da3b199ad6bf79448779a118355e1465f44723a5f55416de4d4516aa0f949fcb3f393d63021a5a778cfee9a3
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-wasm@npm:7.5.4":
   version: 7.5.4
   resolution: "@polkadot/wasm-crypto-wasm@npm:7.5.4"
@@ -1364,24 +1266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:^7.5.2":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-crypto@npm:7.5.3"
-  dependencies:
-    "@polkadot/wasm-bridge": "npm:7.5.3"
-    "@polkadot/wasm-crypto-asmjs": "npm:7.5.3"
-    "@polkadot/wasm-crypto-init": "npm:7.5.3"
-    "@polkadot/wasm-crypto-wasm": "npm:7.5.3"
-    "@polkadot/wasm-util": "npm:7.5.3"
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 10c0/c84b31215c31dbe8265dc5550ad5598ee0e12fa1fa594852d749755a72ca1327fd6649f5f3aae73eccf48e2a04642e700484d5bf4c724e1fd56127c1944d20fe
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^7.5.3":
+"@polkadot/wasm-crypto@npm:7.5.4":
   version: 7.5.4
   resolution: "@polkadot/wasm-crypto@npm:7.5.4"
   dependencies:
@@ -1398,18 +1283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:7.5.3, @polkadot/wasm-util@npm:^7.5.2":
-  version: 7.5.3
-  resolution: "@polkadot/wasm-util@npm:7.5.3"
-  dependencies:
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: 10c0/6f68b64cc9429b0a1091d66ce4da461b89e1377078ffc79d4ad2d307ecce74eacdfa9971b4b41b8e4e946fd74f0ae8d31a4ba0952dd32ed77c6b1aac01ebd5e4
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-util@npm:7.5.4, @polkadot/wasm-util@npm:^7.5.3":
+"@polkadot/wasm-util@npm:7.5.4":
   version: 7.5.4
   resolution: "@polkadot/wasm-util@npm:7.5.4"
   dependencies:
@@ -1417,16 +1291,6 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: 10c0/a5a42b7d0b401ff68ee22017ad2b55eb0bfbdd1000d13a6e9dd05f374496237c1409a0cf18cfc8bdbd642110ae6c1b6e39a7484e5f8bdecdc48010c66c46b460
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-bigint@npm:13.5.8, @polkadot/x-bigint@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-bigint@npm:13.5.8"
-  dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/50e2c3aa98c09c1b84ab959129e76895ac490bfb0efc28e4a4b43d07914ff9cfc8c90c61711a0b0947ff00bcf4f90b54844cf54f8b930f248e425efd16f9fe54
   languageName: node
   linkType: hard
 
@@ -1440,23 +1304,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-fetch@npm:13.5.8"
+"@polkadot/x-fetch@npm:13.5.9":
+  version: 13.5.9
+  resolution: "@polkadot/x-fetch@npm:13.5.9"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
+    "@polkadot/x-global": "npm:13.5.9"
     node-fetch: "npm:^3.3.2"
     tslib: "npm:^2.8.0"
-  checksum: 10c0/fce35957d3620f7e630c74f81c4a33cebfd8ee4086ad49682ee3ec2b030a76399604da9cef2e20e65c7ce40b48bf2882297dbc1a38420b14a96e15fc3a457ba9
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-global@npm:13.5.8, @polkadot/x-global@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-global@npm:13.5.8"
-  dependencies:
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/aa4ee71e1f9c8147b6034e8809f4bd4186547c207fe923fe38dd8b7b7ac700f9a3add21a080697a9ca4197fb159ea7b9806e99aa627be24fecae5e1960dc2440
+  checksum: 10c0/05f7c83b5a4d711ed20809e25e65ada870e183b2eb9a9316fe336cf0de347620033a622b610cbd8ed824162e3bdbcad789dffbde5679ed541d1431ba499d2d01
   languageName: node
   linkType: hard
 
@@ -1466,19 +1321,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/46c2aca9897c645f3016057f7309008dc0cb3ec087311bc3180e937ea81fdfb56fe0c43385db2c4236edfabc410499e9eb73b5da8db1057741614734cac253fd
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-randomvalues@npm:13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-randomvalues@npm:13.5.8"
-  dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
-    tslib: "npm:^2.8.0"
-  peerDependencies:
-    "@polkadot/util": 13.5.8
-    "@polkadot/wasm-util": "*"
-  checksum: 10c0/0c709a248cc3a64dfb6f075f25f02dc9099156c2b71f0a86caaa1ab126a92b28ea26be8b158e7b167471bb9878a00171791c28d1669af843b7cf03735961728d
   languageName: node
   linkType: hard
 
@@ -1495,16 +1337,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-textdecoder@npm:13.5.8"
-  dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/3d60058f75cd5ff9f3f6f8580ee794da48df90dd813a73e2cf2bf5631d68d698dfb4e0891eb45c2a2eeb640448a395797a55964d56c48aed988a5e88a0e8044b
-  languageName: node
-  linkType: hard
-
 "@polkadot/x-textdecoder@npm:13.5.9":
   version: 13.5.9
   resolution: "@polkadot/x-textdecoder@npm:13.5.9"
@@ -1512,16 +1344,6 @@ __metadata:
     "@polkadot/x-global": "npm:13.5.9"
     tslib: "npm:^2.8.0"
   checksum: 10c0/69de94eb570e91e3f66efdf6fdc47faae406f66cfe9afed2907fc4ea5bbc062405236a31dcb3d1ebfe15c5681e9f3ce610db25b25643c52c9e1608ed1755bafe
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-textencoder@npm:13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-textencoder@npm:13.5.8"
-  dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/b264698723eed2d4f97ffee11837ea7ff654d3288fb24f2a2e86b6a5e828dd46e4e01b6ea85bd26c5d3b0a0faf4d11ecb7d5df78f6a7891947491b9c0eef5636
   languageName: node
   linkType: hard
 
@@ -1535,14 +1357,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^13.5.8":
-  version: 13.5.8
-  resolution: "@polkadot/x-ws@npm:13.5.8"
+"@polkadot/x-ws@npm:13.5.9":
+  version: 13.5.9
+  resolution: "@polkadot/x-ws@npm:13.5.9"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.8"
+    "@polkadot/x-global": "npm:13.5.9"
     tslib: "npm:^2.8.0"
     ws: "npm:^8.18.0"
-  checksum: 10c0/a8506d7003613ed4c5f323f4b0016c6a1f6758834d762f06a80de51b7c8e8334fb0d0c3956256b9155346b41c2c9c08556a6bdef6a9ccda9a433aad4d64f92f3
+  checksum: 10c0/6e0fa0da252a4e0e70e758a0fabdee451178c3bd24fb1ef87445671fc6d25d68a4f0021781126000923406ba74e6623d103492b6cad164e651fb4068be72d97b
   languageName: node
   linkType: hard
 
@@ -1558,15 +1380,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/polymesh-sdk@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@polymeshassociation/polymesh-sdk@npm:30.0.0"
+"@polymeshassociation/polymesh-sdk@npm:30.1.0":
+  version: 30.1.0
+  resolution: "@polymeshassociation/polymesh-sdk@npm:30.1.0"
   dependencies:
     "@apollo/client": "npm:^3.8.1"
     "@polkadot/api": "npm:16.5.2"
     "@polkadot/util": "npm:13.5.9"
     "@polkadot/util-crypto": "npm:13.5.9"
-    "@polymeshassociation/polymesh-types": "npm:^7.4.0"
+    "@polymeshassociation/polymesh-types": "npm:^7.5.0"
     bignumber.js: "npm:9.0.1"
     cross-fetch: "npm:^4.0.0"
     dayjs: "npm:1.11.9"
@@ -1578,20 +1400,20 @@ __metadata:
     semver: "npm:^7.5.4"
     ts-morph: "npm:^25.0.1"
     ws: "npm:^8.18.3"
-  checksum: 10c0/c1689fc9ef7632d9f7743dce0e4250f8a7005e161fac034b3d0f02530dea50152a9b21fd5e6bb08d5f5bd2ace22494b9194ba0129d36c966c9310673c120f4e5
+  checksum: 10c0/29c4634d6717d3e8b444858ba763b77a021c7ac0c9895ae0535130d6dc3e6ddb549d42d57a24a719960de17f75aedd2013fdfe6f2f6c3397b366ac4935119534
   languageName: node
   linkType: hard
 
-"@polymeshassociation/polymesh-types@npm:^7.4.0":
-  version: 7.4.0
-  resolution: "@polymeshassociation/polymesh-types@npm:7.4.0"
+"@polymeshassociation/polymesh-types@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "@polymeshassociation/polymesh-types@npm:7.5.0"
   dependencies:
     "@polkadot/api": "npm:16.5.2"
     "@polkadot/api-base": "npm:16.5.2"
     "@polkadot/rpc-core": "npm:16.5.2"
     "@polkadot/types": "npm:16.5.2"
     "@polkadot/types-codec": "npm:16.5.2"
-  checksum: 10c0/e0ba7d34eee7171f8ed02dfe47295fdbb55bcc4b315d327a724312242fcea3b485064f64a453c9f13cdd1b75197626714482a0e16fe15274223bd3f150c554b8
+  checksum: 10c0/cdb8191954e864e5eee65aca83205b6e2e002c7bcf78b6bc6a24d101bc09e0d904d7015a08dd3734cdead839bc457b9acb884d5799fae73a52ab4de131d7c03c
   languageName: node
   linkType: hard
 
@@ -6579,7 +6401,7 @@ __metadata:
   resolution: "polymesh-dev-env@workspace:."
   dependencies:
     "@polymeshassociation/local-signing-manager": "npm:^4.1.1"
-    "@polymeshassociation/polymesh-sdk": "npm:30.0.0"
+    "@polymeshassociation/polymesh-sdk": "npm:30.1.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.15.17"
     "@typescript-eslint/eslint-plugin": "npm:4.29.0"


### PR DESCRIPTION
## Summary

The `Run Tests` workflow could not complete. Vault crash-looped on the GitHub runners so the environment never came up, and once that was fixed a series of further failures surfaced behind it — admin accounts running out of POLYX, a job timeout that cancelled the run before diagnostics could print, and a settlement test asserting on state that can no longer occur on chain v8.

This gets the workflow running end to end and fixes the failures it exposed. Also adds a small unrelated quality-of-life change: disabling the third-party ad slots the upstream Blockscout frontend ships with.

## Changes

### Vault would not start on CI runners

`cap_add: IPC_LOCK` was inert — the image runs as non-root (uid 100) and `/bin/vault` carries no `cap_ipc_lock` file capability, so the capability never reached the process's effective set and `mlock` stayed bound by `RLIMIT_MEMLOCK`. That limit is unlimited in containers on a typical workstation but finite on the runners, which is why this only ever reproduced in CI. Reproduced locally with `--ulimit memlock=67108864` to confirm.

Drops the inert `cap_add` and sets `disable_mlock` in the Vault config. Not version specific — `hashicorp/vault:1.20.4` has no file capability either, so pinning `VAULT_VERSION` would not have helped.

The Vault service is now documented as development only, since a reader copying it would otherwise inherit no TLS, a single unseal key, and a plaintext root token on a shared volume.

### Failures reported no cause

`start-env.sh` runs `docker compose up --detach`, which never attaches to container stdout, so a failing one-shot service such as `vault-init` reported only `didn't complete successfully: exit 1`. It now dumps `ps --all` and `logs` on failure, both locally and in CI.

`vault-init.sh` also checks readiness before reading the token file, so a timeout no longer emits an empty `Vault Root Token:` line and a stray `cat` error, and no longer marks the service available on a failed run.

### CI job structure

The job hit its 20 minute ceiling. Because that is a *job-level* timeout, GitHub cancels the job rather than failing it, so the `if: failure()` diagnostics step never ran and the run reported no logs at all.

`yarn test` is split into `test:start` and `test:run` with their own step timeouts, sized from a measured run (5m22s startup against 12 minutes, 27m45s suite against 40). The job ceiling sits above their sum so an overrunning phase trips its own step timeout while the job still has budget to dump logs. Teardown moves to an `if: always()` step, since `test.sh` uses `set -e` and skipped it whenever anything failed. `checkout` and `setup-node` bumped to v5 to clear the Node 20 deprecation warning.

### Test admins ran out of POLYX

34 of 56 suites failed with `Insufficient free balance` and `does not have enough POLYX balance to pay this transaction's fees`.

Each Jest worker has its own admin, and that admin paid 100,000 POLYX for every identity its suites create. The suite creates ~80 identities across 8 workers, so demand was 8,000,000 against a supply of 8 × 1,000,000 — exactly 100% subscribed, with nothing left for fees. An admin could afford 10 identities and needed 10 on average, so any worker handed an above-average share of suites ran dry, which is why roughly half the suites failed rather than all or none.

The admin float cannot absorb it: `createTestAdmins` transfers from a finite source account and fails on chain with `FundsUnavailable` when asked for more than it holds. Probing a local environment showed 8 × 1,000,000 succeeding while both 8 × 2,500,000 and 8 × 10,000,000 failed outright, leaving every admin empty.

So the headroom comes from the other side: 25,000 POLYX per identity cuts demand to 2,000,000 and leaves 4x headroom per worker, while still dwarfing what a suite spends (protocol fees are 2,500 to create an asset and 500 for a ticker, and no test moves more than 1,000 POLYX). The `createTestAdmins` response is now checked too, so a funding failure fails the run at its cause instead of as hundreds of unrelated test failures.

### `controllerTransfer` asserted on impossible state

The test timed out on `the counter party should have the instruction as pending`. Probing a local v8 environment showed two reasons it can never be there, and that the assertion was asking for the wrong thing.

Receiver affirmation is automatic from v8 unless the receiver opts in through `settlement.setMandatoryReceiverAffirmation`. The counter party only receives on this single-leg instruction, so it is affirmed at submission and lands in its `affirmed` list, never in `pending`. (The sibling in `sdk/settlements/tradeAssets.ts` still passes because its counter party *sends* on the second leg, and a sender must always affirm.)

The instruction also carried an `endBlock` 50 blocks out, added when the suite moved to 8.x to stop instructions auto-settling. That makes it `SettleOnBlock`, so it stays `Pending` until that block regardless of affirmations — and the controller transfer that follows needs the counter party to actually hold the asset. Waiting for a pending affirmation could never produce that; only settlement can.

Now drops the end block and waits for the instruction to execute, affirming as the receiver only when the chain requires it (which keeps the example working on 7.x). Reading the instruction's own chain state also removes the dependency on the counter party's middleware-backed instruction list, which lags the chain under load.

While in there: the holder checks were `expect(x.balance.eq(y))` with no matcher, so they asserted nothing and let an unsettled transfer through. They now compare balances properly, and the middleware is given a chance to catch up with the controller transfers before holders are read.

### Dependencies

`@polkadot/util`, `util-crypto` and the `wasm-crypto` packages were each being installed twice, at 13.5.8 and 13.5.9, one hoisted and one under the SDK. Now pinned to the versions the SDK resolves. SDK bumped to 30.1.0.

Note this does *not* silence the `@polkadot/x has multiple versions` banners in the test output — those are the same version registering itself twice through its ESM and CJS entry points under Jest, reported through the same warning.

### Blockscout ads

The upstream frontend image enables third-party ad slots by default (a banner on the home page and a text ad on token pages). Disabled here, with `POLYMESH_BLOCKSCOUT_AD_BANNER_PROVIDER` / `..._AD_TEXT_PROVIDER` to re-enable.

## Verification

- `controllerTransfer` passes locally against a fresh dev environment (`✓ should execute controllerTransfer without errors`), run twice.
- Vault mlock failure reproduced locally with a finite memlock rlimit and confirmed fixed.
- `createTestAdmins` funding ceiling probed directly against a local environment.
- Typecheck and lint clean on all touched files.
- The most recent CI run reached 250 of 257 tests passing, with `controllerTransfer` the only genuine remaining failure — that is the fix in this PR, so a green run is expected but has not been observed yet.

## Notes for reviewers

- The step timeouts are sized from a run that *failed*. A fully green run does strictly more work than one that aborts suites early, so the 40 minute suite limit is the one to revisit if it proves tight.
- `nonFungibleAssetControllerTransfer` is unused but received the same fix, to keep the two examples consistent.