### PR TITLE
test: restore the dividend distribution self-claim step

### DIFF
--- a/tests/src/__tests__/rest/corporate-actions/dividend-distributions.ts
+++ b/tests/src/__tests__/rest/corporate-actions/dividend-distributions.ts
@@ -4,6 +4,7 @@ import { createAssetParams } from '~/rest/assets/params';
 import { createCheckpointParams } from '~/rest/checkpoints/params';
 import { ProcessMode } from '~/rest/common';
 import {
+  claimDividendDistributionParams,
   createDividendDistributionParams,
   modifyDistributionCheckpointParams,
   payDividendDistributionParams,
@@ -213,18 +214,26 @@ describe('Dividend Distributions', () => {
     expect(distributions.results[0].id).toBe(distributionId);
   });
 
-  // NOTE: a "claimant self-claims via `capitalDistribution.claim`" step was removed here.
-  // It consistently rejects with "The signing Identity is not included in this Distribution"
-  // (the SDK's DividendDistribution.getParticipant() returns null), even though:
-  //   - claimant's checkpoint-time balance is confirmed correct (see the diagnostic assertion
-  //     in "should create a dividend distribution", which checks the same checkpoint directly)
-  //   - targets uses the default Exclude:[] (everyone included), so target-list membership
-  //     isn't the issue
-  //   - the equivalent push-based payment (to the holder, above) succeeds against the same
-  //     distribution/checkpoint
-  // This looks like a genuine discrepancy between getParticipant()'s internal checkpoint-balance
-  // resolution and the identical query made directly through the checkpoint-balances endpoint,
-  // rather than anything wrong with these params. Needs SDK-level investigation to pin down.
+  it('claimant should be able to claim the distribution', async () => {
+    const params = claimDividendDistributionParams({
+      options: { processMode: ProcessMode.Submit, signer: claimant.signer },
+    });
+
+    const result = await restClient.corporateActions.claimDividendDistribution(
+      assetId,
+      distributionId,
+      params
+    );
+    expect(result).toMatchObject({
+      transactions: expect.arrayContaining([
+        {
+          transactionTag: 'capitalDistribution.claim',
+          type: 'single',
+          ...expectBasicTxInfo,
+        },
+      ]),
+    });
+  });
 
   it('should reclaim the distribution', async () => {
     const remainingMs = expiryDate.getTime() - Date.now();
@@ -252,7 +261,7 @@ describe('Dividend Distributions', () => {
   });
 
   it('should be able to get payment history', async () => {
-    // only the holder was actually paid (pushed); the claimant's claim step above is skipped
+    // the holder was paid via a push; the claimant claimed their own share above
     const result = await restClient.corporateActions.paymentHistory(assetId, distributionId);
     expect(result).toMatchObject({
       results: expect.arrayContaining([


### PR DESCRIPTION
## Summary

Restores the `claimant should be able to claim the distribution` step in `dividend-distributions.ts`, removed in #44 pending SDK-level investigation of `capitalDistribution.claim` consistently rejecting with `'The signing Identity is not included in this Distribution'` for a genuine, funded participant.

## Root cause (found and fixed upstream)

`prepareClaimDividends` called `distribution.getParticipant()` with no args, letting it default the identity to check via `distribution.context.getSigningIdentity()`. The `DividendDistribution` entity carries whatever `Context` it happened to be *fetched* with, which for a long-lived, multi-account consumer like polymesh-rest-api is a different object than the Procedure's own per-call `Context` (scoped to that call's `signingAccount`). So the check ran against whatever Identity the shared Context's `signingAddress` last pointed to, not the Identity actually signing the claim.

Confirmed live against a real chain v8 node + polymesh-rest-api, with temporary debug instrumentation in the running REST API's SDK copy — it was resolving a completely unrelated Identity with a 0 balance, hence the deterministic "not included" rejection.

Fixed upstream in [PolymeshAssociation/polymesh-sdk#1663](https://github.com/PolymeshAssociation/polymesh-sdk/pull/1663).

## ⚠️ This PR will fail CI until the SDK fix ships

This restores the test as it should be once the fix lands, but `polymesh-rest-api:v9.0.0-alpha.1` (used by `envs/local`/`envs/8.0`) still bundles the unfixed SDK 31.0.0. **Do not merge until `polymesh-rest-api` has bumped to a SDK release containing #1663**, at which point this suite should go green as-is.

## Test plan

- [x] Verified live: patched the fix directly into a running `polymesh-rest-api` container's SDK copy and reran this exact suite against a real chain v8 node — 13/13 passing, including the restored claim step
- [ ] Re-run in CI once `polymesh-rest-api`'s SDK dependency includes PolymeshAssociation/polymesh-sdk#1663